### PR TITLE
Inline support with Treesitter & Ignore Prefix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,16 @@ use {
 
 ## Usage
 
-Switcher has 3 functions. `switch`, `toggle`, and `find`. No setup function call required. Just call a function with the desired arguments.
+Switcher has 4 functions. `switch`, `toggle`, `find`, `inline_ts_switch`. No setup function call required. Just call a function with the desired arguments.
 
 For more examples, see `Recipes`
 
 ### ➡️ Switch
 *Gets "prefix" of file name, switches to `prefix`.`suffix`*
+
+`switch(search_string, options)`
+
+#### Example
 
 `require('nvim-quick-switcher').switch('component.ts')`
 - `ticket.component.html` --> `ticket.component.ts`
@@ -61,6 +65,9 @@ For more examples, see `Recipes`
 ### 🔄 Toggle
 *Toggles `prefix`.`suffix`, based on current suffix / file extension*
 
+`toggle(search_string_one, search_string_two)`
+
+#### Example
 `require('nvim-quick-switcher').toggle('cpp', 'h')`
 - `node.cpp` --> `node.h`
 - `node.h` --> `node.cpp`
@@ -68,6 +75,9 @@ For more examples, see `Recipes`
 ### 🔍 Find 
 *Uses gnu/linux `find` & `grep` to find file and switch to `prefix`+`pattern`*
 
+`find(search_string, options)`
+
+#### Example
 `require('nvim-quick-switcher').find('*query*')`
 - Allows wild cards, i.e. first argument is search parameter for gnu/linux find
 - file: `ticket.component.ts` --> pattern: `ticket*query*`
@@ -97,13 +107,23 @@ If no results are found, will search backwards one directory, see `reverse`
 }
 ```
 
-#### Inline Switch (Treesitter)
+### 🌳 Inline Switch (Treesitter)
 Requires `nvim-treesitter/nvim-treesitter`
 
 *Uses treesitter queries to navigate inside of a file*
 
-```lua
+`inline_ts_switch(file_type, query_string, options)`
 
+#### Example
+`require('nvim-quick-switcher').inline_ts_switch('svelte', '(script_element (end_tag) @capture)')`
+- Places cursor at start of `</script>` node
+
+#### Options 
+```lua
+{
+  goto_end = false, -- go to start of node if false, go to end of node if true
+  avoid_set_jump = false, -- do not add to jumplist if true
+}
 ```
 
 ## Recipes (My Binds)
@@ -113,26 +133,40 @@ Requires `nvim-treesitter/nvim-treesitter`
 local keymap = vim.api.nvim_set_keymap
 local opts = { noremap = true, silent = true }
 
+-- Styles
+keymap("n", "<leader>oi", "<cmd>:lua require('nvim-quick-switcher').find('.+css|.+scss|.+sass', { regex = true, prefix='full' })<CR>", opts)
+
+-- Types
+keymap("n", "<leader>orm", "<cmd>:lua require('nvim-quick-switcher').find('.+model.ts|.+models.ts|.+types.ts', { regex = true })<CR>", opts)
+
+-- Util
+keymap("n", "<leader>ol", "<cmd>:lua require('nvim-quick-switcher').find('*util.*', { prefix = 'short' })<CR>", opts)
+
 -- Tests
 keymap("n", "<leader>ot", "<cmd>:lua require('nvim-quick-switcher').find('.+test|.+spec', { regex = true, prefix='full' })<CR>", opts)
 
--- Stylesheets
-keymap("n", "<leader>oi", "<cmd>:lua require('nvim-quick-switcher').find('.+css|.+scss|.+sass', { regex = true, prefix='full' })<CR>", opts)
-
--- Redux-like
-keymap("n", "<leader>oe", "<cmd>:lua require('nvim-quick-switcher').find('*effects*')<CR>", opts)
-keymap("n", "<leader>oa", "<cmd>:lua require('nvim-quick-switcher').find('*actions*')<CR>", opts)
-keymap("n", "<leader>oq", "<cmd>:lua require('nvim-quick-switcher').find('*query*')<CR>", opts)
-keymap("n", "<leader>ow", "<cmd>:lua require('nvim-quick-switcher').find('*store*')<CR>", opts)
-
 -- Angular
-keymap("n", "<leader>os", "<cmd>:lua require('nvim-quick-switcher').find('.service.ts')<CR>", opts)
+keymap("n", "<leader>oy", "<cmd>:lua require('nvim-quick-switcher').find('.service.ts')<CR>", opts)
 keymap("n", "<leader>ou", "<cmd>:lua require('nvim-quick-switcher').find('.component.ts')<CR>", opts)
 keymap("n", "<leader>oo", "<cmd>:lua require('nvim-quick-switcher').find('.component.html')<CR>", opts)
 keymap("n", "<leader>op", "<cmd>:lua require('nvim-quick-switcher').find('.module.ts')<CR>", opts)
 
--- Switches for - or _ e.g. controller-util.lua
-keymap("n", "<leader>ol", "<cmd>:lua require('nvim-quick-switcher').find('*util.*', { prefix='short' })<CR>", opts)
+-- SvelteKit
+keymap("n", "<leader>oso", "<cmd>:lua require('nvim-quick-switcher').find('*page.svelte', { maxdepth = 1, ignore_prefix = true })<CR>", opts)
+keymap("n", "<leader>osi", "<cmd>:lua require('nvim-quick-switcher').find('*layout.svelte', { maxdepth = 1, ignore_prefix = true })<CR>", opts)
+keymap("n", "<leader>osu", "<cmd>:lua require('nvim-quick-switcher').find('.*page.server.ts|.*page.ts', { maxdepth = 1, regex = true, ignore_prefix = true })<CR>", opts)
+
+ -- Inline TS
+keymap("n", "<leader>osj", "<cmd>:lua require('nvim-quick-switcher').inline_ts_switch('svelte', '(script_element (end_tag) @capture)')<CR>", opts)
+keymap("n", "<leader>osk", "<cmd>:lua require('nvim-quick-switcher').inline_ts_switch('svelte', '(style_element (start_tag) @capture)')<CR>", opts)
+
+-- Redux-like
+keymap("n", "<leader>ore", "<cmd>:lua require('nvim-quick-switcher').find('*effects.ts')<CR>", opts)
+keymap("n", "<leader>ora", "<cmd>:lua require('nvim-quick-switcher').find('*actions.ts')<CR>", opts)
+keymap("n", "<leader>orw", "<cmd>:lua require('nvim-quick-switcher').find('*store.ts')<CR>", opts)
+keymap("n", "<leader>orf", "<cmd>:lua require('nvim-quick-switcher').find('*facade.ts')<CR>", opts)
+keymap("n", "<leader>ors", "<cmd>:lua require('nvim-quick-switcher').find('.+query.ts|.+selectors.ts|.+selector.ts', { regex = true })<CR>", opts)
+keymap("n", "<leader>orr", "<cmd>:lua require('nvim-quick-switcher').find('.+reducer.ts|.+repository.ts', { regex = true })<CR>", opts)
 ```
 
 ## Personal Motivation
@@ -145,4 +179,3 @@ I currently use nvim-quick-switcher on a daily basis for Angular Components, Tes
 
 ## Alternatives
 - [projectionist](https://github.com/tpope/vim-projectionist)
-

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Quickly navigate to related/alternate files/extensions based on the current file
   - `state/tasks.query.ts` --> `../tasks.component.ts`
   - `controller.lua` --> `controller_spec.lua`
   - `controller-util.lua` --> `controller-service.lua`
+- 🌳 Navigate inside files with Treesitter Queries
 
 ## Installation
 Vim-plug 
@@ -96,6 +97,15 @@ If no results are found, will search backwards one directory, see `reverse`
 }
 ```
 
+#### Inline Switch (Treesitter)
+Requires `nvim-treesitter/nvim-treesitter`
+
+*Uses treesitter queries to navigate inside of a file*
+
+```lua
+
+```
+
 ## Recipes (My Binds)
 *My configuration for nvim-quick-switcher. Written in Lua*
 
@@ -106,18 +116,16 @@ local opts = { noremap = true, silent = true }
 -- Tests
 keymap("n", "<leader>ot", "<cmd>:lua require('nvim-quick-switcher').find('.+test|.+spec', { regex = true, prefix='full' })<CR>", opts)
 
+-- Stylesheets
+keymap("n", "<leader>oi", "<cmd>:lua require('nvim-quick-switcher').find('.+css|.+scss|.+sass', { regex = true, prefix='full' })<CR>", opts)
+
 -- Redux-like
--- Using find over switch to search with depth incase outside a redux-like folder "/state"
 keymap("n", "<leader>oe", "<cmd>:lua require('nvim-quick-switcher').find('*effects*')<CR>", opts)
 keymap("n", "<leader>oa", "<cmd>:lua require('nvim-quick-switcher').find('*actions*')<CR>", opts)
 keymap("n", "<leader>oq", "<cmd>:lua require('nvim-quick-switcher').find('*query*')<CR>", opts)
 keymap("n", "<leader>ow", "<cmd>:lua require('nvim-quick-switcher').find('*store*')<CR>", opts)
 
--- Stylesheets
-keymap("n", "<leader>oi", "<cmd>:lua require('nvim-quick-switcher').find('.+css|.+scss|.+sass', { regex = true, prefix='full' })<CR>", opts)
-
 -- Angular
--- Using find over switch to look backwards incase in a redux-like folder "/state"
 keymap("n", "<leader>os", "<cmd>:lua require('nvim-quick-switcher').find('.service.ts')<CR>", opts)
 keymap("n", "<leader>ou", "<cmd>:lua require('nvim-quick-switcher').find('.component.ts')<CR>", opts)
 keymap("n", "<leader>oo", "<cmd>:lua require('nvim-quick-switcher').find('.component.html')<CR>", opts)
@@ -125,17 +133,6 @@ keymap("n", "<leader>op", "<cmd>:lua require('nvim-quick-switcher').find('.modul
 
 -- Switches for - or _ e.g. controller-util.lua
 keymap("n", "<leader>ol", "<cmd>:lua require('nvim-quick-switcher').find('*util.*', { prefix='short' })<CR>", opts)
-
--- Legacy
--- keymap("n", "<leader>ou", "<cmd>:lua require('nvim-quick-switcher').switch('component.ts')<CR>", opts)
--- keymap("n", "<leader>oo", "<cmd>:lua require('nvim-quick-switcher').switch('component.html')<CR>", opts)
--- keymap("n", "<leader>oi", "<cmd>:lua require('nvim-quick-switcher').switch('component.scss')<CR>", opts)
--- keymap("n", "<leader>op", "<cmd>:lua require('nvim-quick-switcher').switch('module.ts')<CR>", opts)
--- keymap("n", "<leader>ot", "<cmd>:lua require('nvim-quick-switcher').switch('component.spec.ts')<CR>", opts)
--- keymap("n", "<leader>ovu", "<cmd>:lua require('nvim-quick-switcher').switch('component.ts', { split = 'vertical' })<CR>", opts)
--- keymap("n", "<leader>ovi", "<cmd>:lua require('nvim-quick-switcher').switch('component.scss', { split = 'vertical' })<CR>", opts)
--- keymap("n", "<leader>ovo", "<cmd>:lua require('nvim-quick-switcher').switch('component.html', { split = 'vertical' })<CR>", opts)
--- keymap("n", "<leader>oc", "<cmd>:lua require('nvim-quick-switcher').toggle('cpp', 'h')<CR>", opts)
 ```
 
 ## Personal Motivation

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Quickly navigate to related/alternate files/extensions based on the current file
   - `tasks.component.ts` --> `tasks.module.ts`
   - `tasks.component.ts` --> `tasks.component.spec.ts`
   - `tasks.query.ts` --> `tasks.store.ts`
-- 🐒 Find files by Wilcard or Regex
+- 🐒 Find files by Wilcard (Glob) or Regex 
   - `tasks.ts` --> `tasks.spec.ts` | `tasks.test.ts` 
   - `tasks.ts` --> `tasks.css` | `tasks.scss` | `tasks.sass`
   - `/tasks.components.ts` --> `state/tasks.query.ts` 
@@ -53,6 +53,7 @@ For more examples, see `Recipes`
 {
   split = 'vertical'|'horizontal'|nil -- nil is default
   size = 100 -- # of columns | rows. default is 50% split
+  ignore_prefix = false -- useful for navigating to files like "index.ts" or "+page.svelte"
 }
 ```
 
@@ -91,6 +92,7 @@ If no results are found, will search backwards one directory, see `reverse`
   path = nil, -- overwrite path (experimental).
   prefix = 'default', -- full: stop at last period | short: stop at first _ or - | default: stop at first period.
   regex_type = 'E' -- default regex extended. See grep for types.
+  ignore_prefix = false -- useful for navigating to files like "index.ts" or "+page.svelte"
 }
 ```
 

--- a/lua/nvim-quick-switcher/init.lua
+++ b/lua/nvim-quick-switcher/init.lua
@@ -47,6 +47,7 @@ end
 -- Instead of '.' config/options. Create flexible call-back function.
 function M.switch(suffix, user_config)
   local path_state = get_path_state();
+  if user_config.ignore_prefix then path_state.prefix = '' end
   return navigation(path_state.path .. '/' .. path_state.prefix ..  '.' .. suffix, user_config)
 end
 
@@ -65,6 +66,7 @@ function M.find(input, user_config)
     local path_state = get_path_state();
     local path = config.path and config.path or path_state.path
     local prefix = util.resolve_prefix(path_state, config.prefix)
+    if user_config.ignore_prefix then prefix = '' end
     local base_find = [[find ]] .. path .. [[ -maxdepth ]] .. config.maxdepth
     local name_based = ' -name ' .. [[']] .. prefix .. input .. [[']]
     local regex_based = ' -name ' .. [[']] .. prefix .. [[*']] .. [[ | grep ]] .. '-' .. config.regex_type  .. [[ ']] .. input .. [[']]

--- a/lua/nvim-quick-switcher/init.lua
+++ b/lua/nvim-quick-switcher/init.lua
@@ -47,8 +47,10 @@ end
 -- Instead of '.' config/options. Create flexible call-back function.
 function M.switch(suffix, user_config)
   local path_state = get_path_state();
-  if user_config.ignore_prefix then path_state.prefix = '' end
-  return navigation(path_state.path .. '/' .. path_state.prefix ..  '.' .. suffix, user_config)
+  local ignore_prefix = user_config ~= nil and user_config.ignore_prefix == true
+  local prefix = path_state.prefix ..  '.'
+  if ignore_prefix then prefix = '' end
+  return navigation(path_state.path .. '/' .. prefix .. suffix, user_config)
 end
 
 function M.toggle(suffixOne, suffixTwo)
@@ -66,7 +68,7 @@ function M.find(input, user_config)
     local path_state = get_path_state();
     local path = config.path and config.path or path_state.path
     local prefix = util.resolve_prefix(path_state, config.prefix)
-    if user_config.ignore_prefix then prefix = '' end
+    if config.ignore_prefix then prefix = '' end
     local base_find = [[find ]] .. path .. [[ -maxdepth ]] .. config.maxdepth
     local name_based = ' -name ' .. [[']] .. prefix .. input .. [[']]
     local regex_based = ' -name ' .. [[']] .. prefix .. [[*']] .. [[ | grep ]] .. '-' .. config.regex_type  .. [[ ']] .. input .. [[']]

--- a/lua/nvim-quick-switcher/init.lua
+++ b/lua/nvim-quick-switcher/init.lua
@@ -1,4 +1,5 @@
 local util = require('nvim-quick-switcher.util')
+local ts = require('nvim-quick-switcher.ts')
 
 local M = {}
 
@@ -61,6 +62,12 @@ function M.toggle(suffixOne, suffixTwo)
   end
 
   return navigation(path_state.path .. '/' .. path_state.prefix ..  '.' .. suffix)
+end
+
+function M.inline_ts_switch(file_type, query_string, user_config)
+    local config = util.prop_factory(util.default_inline_config(), user_config)
+    local query = vim.treesitter.parse_query(file_type, query_string)
+    ts.go_to_node(file_type, query, config.goto_end, config.avoid_set_jump)
 end
 
 function M.find(input, user_config)

--- a/lua/nvim-quick-switcher/ts.lua
+++ b/lua/nvim-quick-switcher/ts.lua
@@ -1,0 +1,26 @@
+-- TS Utils
+local M = {}
+
+local ts_utils = require 'nvim-treesitter.ts_utils'
+
+local get_root = function(bufnr, file_type)
+  local parser = vim.treesitter.get_parser(bufnr, file_type, {})
+  local tree = parser:parse()[1]
+  return tree:root()
+end
+
+M.go_to_node = function(file_type, query, goto_end, avoid_set_jump)
+  local bufnr = vim.api.nvim_get_current_buf()
+  if vim.bo[bufnr].filetype ~= file_type then
+     return
+  end
+
+  local root = get_root(bufnr, file_type)
+  for id, node in query:iter_captures(root, bufnr, 0, -1) do
+    ts_utils.goto_node(node, goto_end, avoid_set_jump)
+    return
+  end
+end
+-- End
+
+return M

--- a/lua/nvim-quick-switcher/util.lua
+++ b/lua/nvim-quick-switcher/util.lua
@@ -48,6 +48,7 @@ function M.default_find_config()
       reverse = true,
       prefix = 'default',
       regex_type = 'E',
+      ignore_prefix = false
     }
 end
 

--- a/lua/nvim-quick-switcher/util.lua
+++ b/lua/nvim-quick-switcher/util.lua
@@ -40,6 +40,13 @@ function M.resolve_prefix(path_state, option)
   end
 end
 
+function M.default_inline_config()
+  return {
+      goto_end = false,
+      avoid_set_jump = false,
+    }
+end
+
 function M.default_find_config()
   return {
       maxdepth = 2,


### PR DESCRIPTION
New public method `inline_ts_switch` uses treesitter to navigate to nodes inside of a file. Also added an ignore prefix flag to `switch` and `find` to support navigating to files like `index.ts` or `+page.svelte` where the "prefix" is always the same.