### PR TITLE
Add support for prefix function and add long prefix option

### DIFF
--- a/lua/nvim-quick-switcher/init.lua
+++ b/lua/nvim-quick-switcher/init.lua
@@ -35,12 +35,14 @@ local function get_path_state()
   local full_suffix = file_name:match('[%-%w_]+%.(.*)')
   local full_prefix = file_name:match('([%-%w_%.]+)%.%w+$')
   local short_prefix = file_name:match('[%w]+')
+  local long_prefix = file_name:match("([%w_%-]+)[%-_]")
   return {
     path = path,
     prefix = prefix,
     full_prefix = full_prefix,
     full_suffix = full_suffix,
     short_prefix = short_prefix,
+    long_prefix = long_prefix,
     file_name = file_name
   }
 end

--- a/lua/nvim-quick-switcher/util.lua
+++ b/lua/nvim-quick-switcher/util.lua
@@ -31,13 +31,26 @@ function M.prop_factory(defaults, props)
 end
 
 function M.resolve_prefix(path_state, option)
-  if option == 'short' then
-    return path_state.short_prefix
-  elseif option == 'full' then
-    return path_state.full_prefix
-  else
-    return path_state.prefix
-  end
+	if type(option) == "string" then
+		if option == "short" then
+			return path_state.short_prefix
+		elseif option == "full" then
+			return path_state.full_prefix
+		elseif option == "long" then
+			return path_state.long_prefix
+		else
+			return path_state.prefix
+		end
+	elseif type(option) == "function" then
+		local buf_name = vim.api.nvim_buf_get_name(0)
+		local file_name = buf_name:match(".+/(.+)%.")
+		local file_extension = buf_name:match(".+%.(%w+)$")
+		local custom_prefix = option(file_name, file_extension)
+		if custom_prefix == nil then
+			return path_state.prefix
+		end
+		return custom_prefix
+	end
 end
 
 function M.default_inline_config()


### PR DESCRIPTION
This PR adds 2 things:

- Add support for specifying the prefix as a function 
- Adds extra convenient prefix option (long):

Current prefix options don't allow for all file naming patterns, here is one example:

In dart it is common to have names like: home_feed_page.dart and home_feed_notifier.dart

If I wanted to create a key bind that would allow me to jump from the home_feed_page.dart to  home_feed_notifier.dart
the current options would not cut it. 

long_prefix will capture  up to but not including the last _ on -. Which can be used like this: 

```lua
require("nvim-quick-switcher").find(".+_notifier\\.", {
    regex = true,
    maxdepth = 4,
    prefix = "long",
  })

```

Function support will generalize further to allow all possible file patterns and even relating file names that don't have a similar structure.