### PR TITLE
Add option to only switch to existing file

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ For more examples, see `Recipes`
 ### 🔄 Toggle
 *Toggles `prefix`.`suffix`, based on current suffix / file extension*
 
-`toggle(search_string_one, search_string_two)`
+`toggle(search_string_one, search_string_two, options)`
+
+For `options` see `Common Options`
 
 #### Example
 `require('nvim-quick-switcher').toggle('cpp', 'h')`
@@ -170,6 +172,19 @@ file_type -- (task-util.lua) --> lua
 file_name -- (src/tasks/task-util.lua) --> task-util.lua
 path -- (src/tasks/task-util.lua) --> src/tasks/task-util.lua
 ```
+
+### 🌌 Common Options
+Options common for file location functions (`switch/toggle/find/find_by_fn`).
+```lua
+{
+  only_existing = false,
+  only_existing_notify = false,
+}
+```
+`only_existing` Causes the switcher to check if the target file exists
+before switching to it.
+`only_existing_notify` will print if the file does not exist.
+
 
 ## Recipes (My Keymaps)
 *My configuration for nvim-quick-switcher. Written in Lua*

--- a/lua/nvim-quick-switcher/init.lua
+++ b/lua/nvim-quick-switcher/init.lua
@@ -65,14 +65,14 @@ function M.switch(suffix, user_config)
   return navigation(path_state.path .. '/' .. prefix .. suffix, user_config)
 end
 
-function M.toggle(suffixOne, suffixTwo)
+function M.toggle(suffixOne, suffixTwo, user_config)
   local path_state = get_path_state();
   local suffix = suffixOne;
   if path_state.full_suffix == suffix then
     suffix = suffixTwo
   end
 
-  return navigation(path_state.path .. '/' .. path_state.prefix .. '.' .. suffix)
+  return navigation(path_state.path .. '/' .. path_state.prefix .. '.' .. suffix, user_config)
 end
 
 function M.inline_ts_switch(file_type, query_string, user_config)

--- a/lua/nvim-quick-switcher/init.lua
+++ b/lua/nvim-quick-switcher/init.lua
@@ -13,6 +13,13 @@ end
 
 local function navigation(file_name, options)
   local isSplit = options ~= nil and options.split ~= nil
+
+  local checkIfExists = options ~= nil and options.only_existing
+  if (checkIfExists and vim.fn.filereadable(file_name) == 0) then
+    if (options.only_existing_notify) then vim.print(file_name .. ' does not exist.') end
+    return;
+  end
+
   if (isSplit) then
     openSplit(options);
   end

--- a/lua/nvim-quick-switcher/ts.lua
+++ b/lua/nvim-quick-switcher/ts.lua
@@ -12,7 +12,7 @@ end
 M.go_to_node = function(file_type, query, goto_end, avoid_set_jump)
   local bufnr = vim.api.nvim_get_current_buf()
   if vim.bo[bufnr].filetype ~= file_type then
-     return
+    return
   end
 
   local root = get_root(bufnr, file_type)

--- a/lua/nvim-quick-switcher/util.lua
+++ b/lua/nvim-quick-switcher/util.lua
@@ -1,33 +1,33 @@
 local M = {}
 
 function M.listToTable(list, filterFn)
-  local t = {}
-  for item in list:gmatch("[^\r\n]+") do
-    if (not filterFn or not filterFn(item)) then
-      table.insert(t, item);
-    else
-    end
-  end
-  return t
+	local t = {}
+	for item in list:gmatch("[^\r\n]+") do
+		if (not filterFn or not filterFn(item)) then
+			table.insert(t, item);
+		else
+		end
+	end
+	return t
 end
 
 function M.readCmd(cmd)
-  local handle = io.popen(cmd);
-  local result = handle:read('*a')
-  handle:close()
-  return result;
+	local handle = io.popen(cmd);
+	local result = handle:read('*a')
+	handle:close()
+	return result;
 end
 
 function M.prop_factory(defaults, props)
-  if props == nil then
-      return defaults
-  end
+	if props == nil then
+		return defaults
+	end
 
-  for k, v in pairs(props) do
-    defaults[k] = v
-  end
+	for k, v in pairs(props) do
+		defaults[k] = v
+	end
 
-  return defaults;
+	return defaults;
 end
 
 function M.resolve_prefix(path_state, option)
@@ -54,22 +54,22 @@ function M.resolve_prefix(path_state, option)
 end
 
 function M.default_inline_config()
-  return {
-      goto_end = false,
-      avoid_set_jump = false,
-    }
+	return {
+		goto_end = false,
+		avoid_set_jump = false,
+	}
 end
 
 function M.default_find_config()
-  return {
-      maxdepth = 2,
-      regex = false,
-      path = nil,
-      reverse = true,
-      prefix = 'default',
-      regex_type = 'E',
-      ignore_prefix = false
-    }
+	return {
+		maxdepth = 2,
+		regex = false,
+		path = nil,
+		reverse = true,
+		prefix = 'default',
+		regex_type = 'E',
+		ignore_prefix = false
+	}
 end
 
 return M


### PR DESCRIPTION
This PR has one main component and one minor component:
* Minor: Formatting from lua_ls, there was lots of mixed indentation that lua_ls formatted, unfortunately made the diff messy.
* Major: Add two options around switching to only existing files.

I had run into a minor annoyance when working in different projects where some are set up with inline templates.
Out of habit I would try to switch anyways, opening an empty buffer.

Added are two options
```lua
{
  only_existing = false,
  only_existing_notify = false,
}
```

`only_existing = true,` will cause `navigation` to return before navigating to a non-existing file.
`only_existing_notify = true,` will also print when the missing file was not switched to.

These options apply to functions that use `navigation`: `switch/toggle/find/find_by_fn`